### PR TITLE
Add `adminFee` to loan receipt and fix surplus distribution in `onCollateralLiquidated()`

### DIFF
--- a/contracts/test/TestCollateralLiquidatorJig.sol
+++ b/contracts/test/TestCollateralLiquidatorJig.sol
@@ -94,7 +94,7 @@ contract TestCollateralLiquidatorJig is ERC165, ERC721Holder, ICollateralLiquida
      * @param encodedLoanReceipt Encoded loan receipt
      */
     function liquidate(bytes calldata encodedLoanReceipt) external {
-        LoanReceipt.LoanReceiptV1 memory loanReceipt = LoanReceipt.decode(encodedLoanReceipt);
+        LoanReceipt.LoanReceiptV2 memory loanReceipt = LoanReceipt.decode(encodedLoanReceipt);
 
         IERC721(loanReceipt.collateralToken).approve(_collateralLiquidator, loanReceipt.collateralTokenId);
 
@@ -114,7 +114,7 @@ contract TestCollateralLiquidatorJig is ERC165, ERC721Holder, ICollateralLiquida
      * @param proceeds Liquidation proceeds in currency tokens
      */
     function onCollateralLiquidated(bytes calldata loanReceipt, uint256 proceeds) external {
-        LoanReceipt.LoanReceiptV1 memory decodedLoanReceipt = LoanReceipt.decode(loanReceipt);
+        LoanReceipt.LoanReceiptV2 memory decodedLoanReceipt = LoanReceipt.decode(loanReceipt);
 
         /* Force a revert to test try...catch in English Auction */
         if (decodedLoanReceipt.collateralTokenId == 130) {
@@ -208,7 +208,7 @@ contract TestCollateralLiquidatorJigTruncated is ERC721Holder {
      * @param encodedLoanReceipt Encoded loan receipt
      */
     function liquidate(bytes calldata encodedLoanReceipt) external {
-        LoanReceipt.LoanReceiptV1 memory loanReceipt = LoanReceipt.decode(encodedLoanReceipt);
+        LoanReceipt.LoanReceiptV2 memory loanReceipt = LoanReceipt.decode(encodedLoanReceipt);
 
         IERC721(loanReceipt.collateralToken).approve(_collateralLiquidator, loanReceipt.collateralTokenId);
 

--- a/contracts/test/TestLoanReceipt.sol
+++ b/contracts/test/TestLoanReceipt.sol
@@ -20,14 +20,14 @@ contract TestLoanReceipt {
     /**
      * @dev External wrapper function for LoanReceipt.encode()
      */
-    function encode(LoanReceipt.LoanReceiptV1 memory receipt) external pure returns (bytes memory) {
+    function encode(LoanReceipt.LoanReceiptV2 memory receipt) external pure returns (bytes memory) {
         return LoanReceipt.encode(receipt);
     }
 
     /**
      * @dev External wrapper function for LoanReceipt.decode()
      */
-    function decode(bytes calldata encodedReceipt) external pure returns (LoanReceipt.LoanReceiptV1 memory) {
+    function decode(bytes calldata encodedReceipt) external pure returns (LoanReceipt.LoanReceiptV2 memory) {
         return LoanReceipt.decode(encodedReceipt);
     }
 }

--- a/test/LoanReceipt.spec.ts
+++ b/test/LoanReceipt.spec.ts
@@ -29,9 +29,10 @@ describe("LoanReceipt", function () {
   /****************************************************************************/
 
   const loanReceipt = {
-    version: 1,
+    version: 2,
     principal: ethers.BigNumber.from("3000000000000000000"),
     repayment: ethers.BigNumber.from("3040000000000000000"),
+    adminFee: ethers.BigNumber.from("2000000000000000"),
     borrower: "0x0CD36Fa7D9634994231Bc76Fb36938D56C6FE70E",
     maturity: 1685595600,
     duration: 2592000,
@@ -59,9 +60,10 @@ describe("LoanReceipt", function () {
   };
 
   const bundleLoanReceipt = {
-    version: 1,
+    version: 2,
     principal: ethers.BigNumber.from("3000000000000000000"),
     repayment: ethers.BigNumber.from("3040000000000000000"),
+    adminFee: ethers.BigNumber.from("2000000000000000"),
     borrower: "0x0CD36Fa7D9634994231Bc76Fb36938D56C6FE70E",
     maturity: 1685595600,
     duration: 2592000,
@@ -96,13 +98,13 @@ describe("LoanReceipt", function () {
   describe("#hash", async function () {
     it("matches expected hash", async function () {
       expect(await loanReceiptLibrary.hash(await loanReceiptLibrary.encode(loanReceipt))).to.equal(
-        "0x1b8e4a0db3ebef226f2a75983bb2f089c048a4985244aa0b68dd153d6bd4f576"
+        "0x9414e95a13dc6b76244efa189e4ecd940485a3ee1d20b95ab87648604fa4dc25"
       );
     });
 
     it("matches expected hash - bundle loan", async function () {
       expect(await loanReceiptLibrary.hash(await loanReceiptLibrary.encode(bundleLoanReceipt))).to.equal(
-        "0xfabd21001cf8b28b972577a3a9e29fcb10fcf2e6af0ddb53e035b0018e73b9e6"
+        "0x929968409fc1e4b14936d36298a142626c9cc5ee00b2cd22362ddfd4eb4be3c9"
       );
     });
   });
@@ -110,17 +112,17 @@ describe("LoanReceipt", function () {
   describe("#encode", async function () {
     it("successfully encodes loan receipt", async function () {
       const encodedLoanReceipt = await loanReceiptLibrary.encode(loanReceipt);
-      expect(encodedLoanReceipt.length).to.equal(2 + (155 + 48 * 3) * 2);
+      expect(encodedLoanReceipt.length).to.equal(2 + (187 + 48 * 3) * 2);
       expect(encodedLoanReceipt).to.equal(
-        "0x0100000000000000000000000000000000000000000000000029a2241af62c00000000000000000000000000000000000000000000000000002a303fe4b53000000cd36fa7d9634994231bc76fb36938d56c6fe70e00000000647825d00000000000278d007616df65742332f688e0e0b1d293a3162f0904ea00000000000000000000000000000000000000000000000000000000000001c8000000000000000000000de0b6b3a764000000000000000000000de0b6b3a764000000000000000000000e043da61725000000000000000000001bc16d674ec8000000000000000000000de0b6b3a764000000000000000000000e043da617250000000000000000000029a2241af62c000000000000000000000de0b6b3a764000000000000000000000e27c49886e60000"
+        "0x0200000000000000000000000000000000000000000000000029a2241af62c00000000000000000000000000000000000000000000000000002a303fe4b530000000000000000000000000000000000000000000000000000000071afd498d00000cd36fa7d9634994231bc76fb36938d56c6fe70e00000000647825d00000000000278d007616df65742332f688e0e0b1d293a3162f0904ea00000000000000000000000000000000000000000000000000000000000001c8000000000000000000000de0b6b3a764000000000000000000000de0b6b3a764000000000000000000000e043da61725000000000000000000001bc16d674ec8000000000000000000000de0b6b3a764000000000000000000000e043da617250000000000000000000029a2241af62c000000000000000000000de0b6b3a764000000000000000000000e27c49886e60000"
       );
     });
 
     it("successfully encodes bundled loan receipt", async function () {
       const encodedLoanReceipt = await loanReceiptLibrary.encode(bundleLoanReceipt);
-      expect(encodedLoanReceipt.length).to.equal(2 + (155 + 20 + 32 * 2 + 48 * 3) * 2);
+      expect(encodedLoanReceipt.length).to.equal(2 + (187 + 20 + 32 * 2 + 48 * 3) * 2);
       expect(encodedLoanReceipt).to.equal(
-        "0x0100000000000000000000000000000000000000000000000029a2241af62c00000000000000000000000000000000000000000000000000002a303fe4b53000000cd36fa7d9634994231bc76fb36938d56c6fe70e00000000647825d00000000000278d000dcd1bf9a1b36ce34237eeafef220932846bcd82627186392ce4c7e6bbeefb220f87587bf7b64195606e45cc778cced10a691bbe0054b7f8bc63bbcad18155201308c8f3540b07f84f5e0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000de0b6b3a764000000000000000000000de0b6b3a764000000000000000000000e043da61725000000000000000000001bc16d674ec8000000000000000000000de0b6b3a764000000000000000000000e043da617250000000000000000000029a2241af62c000000000000000000000de0b6b3a764000000000000000000000e27c49886e60000"
+        "0x0200000000000000000000000000000000000000000000000029a2241af62c00000000000000000000000000000000000000000000000000002a303fe4b530000000000000000000000000000000000000000000000000000000071afd498d00000cd36fa7d9634994231bc76fb36938d56c6fe70e00000000647825d00000000000278d000dcd1bf9a1b36ce34237eeafef220932846bcd82627186392ce4c7e6bbeefb220f87587bf7b64195606e45cc778cced10a691bbe0054b7f8bc63bbcad18155201308c8f3540b07f84f5e0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000de0b6b3a764000000000000000000000de0b6b3a764000000000000000000000e043da61725000000000000000000001bc16d674ec8000000000000000000000de0b6b3a764000000000000000000000e043da617250000000000000000000029a2241af62c000000000000000000000de0b6b3a764000000000000000000000e27c49886e60000"
       );
     });
   });
@@ -133,6 +135,7 @@ describe("LoanReceipt", function () {
       expect(decodedLoanReceipt.version).to.equal(loanReceipt.version);
       expect(decodedLoanReceipt.principal).to.equal(loanReceipt.principal);
       expect(decodedLoanReceipt.repayment).to.equal(loanReceipt.repayment);
+      expect(decodedLoanReceipt.adminFee).to.equal(loanReceipt.adminFee);
       expect(decodedLoanReceipt.borrower).to.equal(loanReceipt.borrower);
       expect(decodedLoanReceipt.maturity).to.equal(loanReceipt.maturity);
       expect(decodedLoanReceipt.duration).to.equal(loanReceipt.duration);
@@ -156,6 +159,7 @@ describe("LoanReceipt", function () {
       expect(decodedLoanReceipt.version).to.equal(bundleLoanReceipt.version);
       expect(decodedLoanReceipt.principal).to.equal(bundleLoanReceipt.principal);
       expect(decodedLoanReceipt.repayment).to.equal(bundleLoanReceipt.repayment);
+      expect(decodedLoanReceipt.adminFee).to.equal(loanReceipt.adminFee);
       expect(decodedLoanReceipt.borrower).to.equal(bundleLoanReceipt.borrower);
       expect(decodedLoanReceipt.maturity).to.equal(bundleLoanReceipt.maturity);
       expect(decodedLoanReceipt.duration).to.equal(bundleLoanReceipt.duration);
@@ -200,7 +204,7 @@ describe("LoanReceipt", function () {
 
     it("fails on unsupported version", async function () {
       const encodedLoanReceipt = ethers.utils.arrayify(await loanReceiptLibrary.encode(loanReceipt));
-      encodedLoanReceipt[0] = 2;
+      encodedLoanReceipt[0] = 1;
       await expect(loanReceiptLibrary.decode(encodedLoanReceipt)).to.be.revertedWithCustomError(
         loanReceiptLibrary,
         "InvalidReceiptEncoding"

--- a/test/Pool.basic.spec.ts
+++ b/test/Pool.basic.spec.ts
@@ -1895,7 +1895,7 @@ describe("Pool Basic", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -2002,7 +2002,7 @@ describe("Pool Basic", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -2100,7 +2100,7 @@ describe("Pool Basic", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.principal).to.equal(FixedPoint.from("25"));
       expect(decodedLoanReceipt.repayment).to.equal(repayment);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
@@ -2633,7 +2633,7 @@ describe("Pool Basic", function () {
 
       /* Validate loan receipt */
       const decodedNewLoanReceipt = await loanReceiptLib.decode(newLoanReceipt);
-      expect(decodedNewLoanReceipt.version).to.equal(1);
+      expect(decodedNewLoanReceipt.version).to.equal(2);
       expect(decodedNewLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedNewLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(refinanceTx.blockHash!)).timestamp + 15 * 86400
@@ -2697,7 +2697,7 @@ describe("Pool Basic", function () {
 
       /* Validate loan receipt */
       const decodedNewLoanReceipt = await loanReceiptLib.decode(newLoanReceipt);
-      expect(decodedNewLoanReceipt.version).to.equal(1);
+      expect(decodedNewLoanReceipt.version).to.equal(2);
       expect(decodedNewLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedNewLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(refinanceTx.blockHash!)).timestamp + 15 * 86400
@@ -2761,7 +2761,7 @@ describe("Pool Basic", function () {
 
       /* Validate loan receipt */
       const decodedNewLoanReceipt = await loanReceiptLib.decode(newLoanReceipt);
-      expect(decodedNewLoanReceipt.version).to.equal(1);
+      expect(decodedNewLoanReceipt.version).to.equal(2);
       expect(decodedNewLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedNewLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(refinanceTx.blockHash!)).timestamp + 15 * 86400

--- a/test/Pool.bundle.ranged.spec.ts
+++ b/test/Pool.bundle.ranged.spec.ts
@@ -334,7 +334,7 @@ describe("Pool Bundle Ranged Collection", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -440,7 +440,7 @@ describe("Pool Bundle Ranged Collection", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -525,7 +525,7 @@ describe("Pool Bundle Ranged Collection", function () {
 
       /* Validate loan receipt */
       const decodedNewLoanReceipt = await loanReceiptLib.decode(newLoanReceipt);
-      expect(decodedNewLoanReceipt.version).to.equal(1);
+      expect(decodedNewLoanReceipt.version).to.equal(2);
       expect(decodedNewLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedNewLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(refinanceTx.blockHash!)).timestamp + 15 * 86400

--- a/test/Pool.bundle.spec.ts
+++ b/test/Pool.bundle.spec.ts
@@ -431,7 +431,7 @@ describe("Pool Bundle", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -548,7 +548,7 @@ describe("Pool Bundle", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -657,7 +657,7 @@ describe("Pool Bundle", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -860,7 +860,7 @@ describe("Pool Bundle", function () {
 
       /* Validate loan receipt */
       const decodedNewLoanReceipt = await loanReceiptLib.decode(newLoanReceipt);
-      expect(decodedNewLoanReceipt.version).to.equal(1);
+      expect(decodedNewLoanReceipt.version).to.equal(2);
       expect(decodedNewLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedNewLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(refinanceTx.blockHash!)).timestamp + 15 * 86400

--- a/test/Pool.erc1155.spec.ts
+++ b/test/Pool.erc1155.spec.ts
@@ -415,7 +415,7 @@ describe("Pool ERC1155", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -537,7 +537,7 @@ describe("Pool ERC1155", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -651,7 +651,7 @@ describe("Pool ERC1155", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -865,7 +865,7 @@ describe("Pool ERC1155", function () {
 
       /* Validate loan receipt */
       const decodedNewLoanReceipt = await loanReceiptLib.decode(newLoanReceipt);
-      expect(decodedNewLoanReceipt.version).to.equal(1);
+      expect(decodedNewLoanReceipt.version).to.equal(2);
       expect(decodedNewLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedNewLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(refinanceTx.blockHash!)).timestamp + 15 * 86400

--- a/test/Pool.multiToken.ranged.spec.ts
+++ b/test/Pool.multiToken.ranged.spec.ts
@@ -335,7 +335,7 @@ describe("Pool Batch Ranged Collection", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -441,7 +441,7 @@ describe("Pool Batch Ranged Collection", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -526,7 +526,7 @@ describe("Pool Batch Ranged Collection", function () {
 
       /* Validate loan receipt */
       const decodedNewLoanReceipt = await loanReceiptLib.decode(newLoanReceipt);
-      expect(decodedNewLoanReceipt.version).to.equal(1);
+      expect(decodedNewLoanReceipt.version).to.equal(2);
       expect(decodedNewLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedNewLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(refinanceTx.blockHash!)).timestamp + 15 * 86400

--- a/test/Pool.ranged.spec.ts
+++ b/test/Pool.ranged.spec.ts
@@ -349,7 +349,7 @@ describe("Pool Ranged Collection", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -453,7 +453,7 @@ describe("Pool Ranged Collection", function () {
 
       /* Validate loan receipt */
       const decodedLoanReceipt = await loanReceiptLib.decode(loanReceipt);
-      expect(decodedLoanReceipt.version).to.equal(1);
+      expect(decodedLoanReceipt.version).to.equal(2);
       expect(decodedLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(borrowTx.blockHash!)).timestamp + 30 * 86400
@@ -529,7 +529,7 @@ describe("Pool Ranged Collection", function () {
 
       /* Validate loan receipt */
       const decodedNewLoanReceipt = await loanReceiptLib.decode(newLoanReceipt);
-      expect(decodedNewLoanReceipt.version).to.equal(1);
+      expect(decodedNewLoanReceipt.version).to.equal(2);
       expect(decodedNewLoanReceipt.borrower).to.equal(accountBorrower.address);
       expect(decodedNewLoanReceipt.maturity).to.equal(
         (await ethers.provider.getBlock(refinanceTx.blockHash!)).timestamp + 15 * 86400

--- a/test/liquidators/EnglishAuctionCollateralLiquidator.spec.ts
+++ b/test/liquidators/EnglishAuctionCollateralLiquidator.spec.ts
@@ -196,9 +196,10 @@ describe("EnglishAuctionCollateralLiquidator", function () {
   /****************************************************************************/
 
   const loanReceiptTemplate = {
-    version: 1,
+    version: 2,
     principal: ethers.BigNumber.from("3000000000000000000"),
     repayment: ethers.BigNumber.from("3040000000000000000"),
+    adminFee: ethers.BigNumber.from("2000000000000000"),
     borrower: "0x0CD36Fa7D9634994231Bc76Fb36938D56C6FE70E",
     maturity: 1685595600,
     duration: 2592000,

--- a/test/liquidators/ExternalCollateralLiquidator.spec.ts
+++ b/test/liquidators/ExternalCollateralLiquidator.spec.ts
@@ -146,9 +146,10 @@ describe("ExternalCollateralLiquidator", function () {
   /****************************************************************************/
 
   const loanReceiptTemplate = {
-    version: 1,
+    version: 2,
     principal: ethers.BigNumber.from("3000000000000000000"),
     repayment: ethers.BigNumber.from("3040000000000000000"),
+    adminFee: ethers.BigNumber.from("2000000000000000"),
     borrower: "0x0CD36Fa7D9634994231Bc76Fb36938D56C6FE70E",
     maturity: 1685595600,
     duration: 2592000,


### PR DESCRIPTION
Need to rebase on top of https://github.com/metastreet-labs/metastreet-contracts-v2/pull/83 to be within contract size limits. After rebasing on top of https://github.com/metastreet-labs/metastreet-contracts-v2/pull/83, the contract sizes will be: 

<img width="886" alt="Screenshot 2023-08-15 at 8 14 13 PM" src="https://github.com/metastreet-labs/metastreet-contracts-v2/assets/12667431/d26c87ff-5e3f-466a-961d-ce6b0a332214">

Gas profile of the current PR (with rebase on top of https://github.com/metastreet-labs/metastreet-contracts-v2/pull/83 ) and the delta compared to current `v2.x`:
```
   Pool Gas Report
    deposit (new tick)                                     215009 (-10)
    deposit (existing tick)                                95337 (-10)
    deposit (existing deposit)                             78237 (-10)
    redeem (partial)                                       120930 (-45)
    redeem (entire)                                        117286 (-45)
    withdraw                                               55100 (-20)
    multicall redeem + rebalance (new tick)                218662 (-75)
    multicall redeem + rebalance (existing tick)           160690 (-75)
    borrow (single, 10 ticks)                              267189 (+103)
    borrow (single, existing, 10 ticks)                    250089 (+103)
    borrow (single, 16 ticks)                              346119 (-145)
    borrow (single, existing, 16 ticks)                    329019 (-145)
    borrow (bundle of 10, 10 ticks)                        284546 (+104)
    borrow (bundle of 10, existing, 10 ticks)              267446 (+104)
    borrow (bundle of 10, 16 ticks)                        363535 (-143)
    borrow (bundle of 10, existing, 16 ticks)              346435 (-143)
    repay (single, 10 ticks)                               245269 (-197)
    repay (single, 16 ticks)                               328290 (-242)
    repay (bundle of 10, 10 ticks)                         265594 (-197)
    repay (bundle of 10, 16 ticks)                         348668 (-242)
    refinance (single, 10 ticks)                           347275 (-2,231)
    refinance (single, 16 ticks)                           464815 (-2,598)
    refinance (bundle of 10, 10 ticks)                     368990 (-4,243)
    refinance (bundle of 10, 16 ticks)                     486673 (-4,611)
    liquidate (single, external, 16 ticks)                 172798 (+303)
    liquidate (bundle of 10, external, 16 ticks)           177317 (+307)
    liquidate (single, english auction, 16 ticks)          250550 (+304)
    liquidate (bundle of 10, english auction, 16 ticks)    661130 (+307)
    bid (first, english auction)                           131095 (0)
    bid (second, english auction)                          86146 (0)
    claim (single, english auction)                        375202 (+407)
    claim (first of bundle, english auction)               119541 (+148)
    claim (middle of bundle, english auction)              85341 (+148)
    claim (last of bundle, english auction)                359661 (+408)
    mint (bundle of 10)                                    241065 (0)
    unwrap (bundle of 10)                                  163565 (0)
```
    
## TO-DO
- [x] Bump loan receipt version and relevant tests 